### PR TITLE
Tweaked 24hr hh:mm:ss format

### DIFF
--- a/src/components/CurrentTime.jsx
+++ b/src/components/CurrentTime.jsx
@@ -7,9 +7,12 @@ function CurrentTime() {
     setTimeNow(new Date())
   }
   setTimeout(changeTime,1000)
+  let hh = String(timeNow.getHours()).length == 2 ? String(timeNow.getHours()) : `0${String(timeNow.getHours())}`;
+  let mm = String(timeNow.getMinutes()).length == 2 ? String(timeNow.getMinutes()) : `0${String(timeNow.getMinutes())}`;
+  let ss = String(timeNow.getSeconds()).length == 2 ? String(timeNow.getSeconds()) : `0${String(timeNow.getSeconds())}`;
   return (
     <div className="currrent-time">
-      {timeNow.getHours()}:{timeNow.getMinutes()}:{timeNow.getSeconds()}
+      {hh}:{mm}:{ss}
     </div>
   )
 }


### PR DESCRIPTION
Corrected bug where single digit times did not have 0 behind them. e.g. 6:04 PM is
6:4:00 instead of 06:04:00